### PR TITLE
[QUICK] filter-operator-fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Fixed
+- Multi filtering issues with AND and OR operations
+
 ## [1.0.0] - 2019-12-06
 ### Added
 - Solr DB Driver Package

--- a/lib/helpers/filters.js
+++ b/lib/helpers/filters.js
@@ -29,9 +29,7 @@ class Filters {
 
 		const filtersGroup = this._parseFilterGroup(filters, modelFields);
 
-		const filtersByType = this._formatByType(filtersGroup);
-
-		return Object.values(filtersByType);
+		return this._formatByType(filtersGroup);
 	}
 
 	static _parseFilterGroup(filterGroup, modelFields) {
@@ -44,58 +42,55 @@ class Filters {
 
 			const filterValues = this._getFilterObjects(filterData, modelField);
 
-			parsedFilterGroup[filterKey] = filterKey in parsedFilterGroup ? [...parsedFilterGroup[filterKey], ...filterValues] : filterValues;
+			parsedFilterGroup.push({ field: filterKey, ...filterValues });
 
 			return parsedFilterGroup;
 
-		}, {});
+		}, []);
 	}
 
 	static _getFilterObjects(filterData, modelField) {
 
-		if(!Array.isArray(filterData))
-			filterData = [filterData];
+		if(!isObject(filterData))
+			filterData = { value: filterData };
 
-		return filterData.map(filterObject => {
+		const { value } = filterData;
 
-			if(!isObject(filterObject))
-				filterObject = { value: filterObject };
+		const type = filterData.type || modelField.type || DEFAULT_FILTER_TYPE;
 
-			const { value } = filterObject;
+		if(!value)
+			throw new SolrError(`Invalid filters: Missing value for filter type ${type}.`, SolrError.codes.INVALID_FILTER_VALUE);
 
-			if(isObject(value) || Array.isArray(value))
-				throw new SolrError('Invalid filters: JSON/Array filters are not supported by Solr.', SolrError.codes.UNSUPPORTED_FILTER);
-
-			const type = filterObject.type || modelField.type || DEFAULT_FILTER_TYPE;
-
-			if(!value)
-				throw new SolrError(`Invalid filters: Missing value for filter type ${type}.`, SolrError.codes.INVALID_FILTER_VALUE);
-
-			return { type, value };
-		});
+		return { type, value };
 	}
 
 	static _formatByType(filtersGroup) {
 
-		return Object.entries(filtersGroup).reduce((filtersByType, [field, filterData]) => {
+		return filtersGroup.reduce((filtersByType, { field, ...filterData }) => {
 
-			filtersByType[field] = this._getFilterByType(field, filterData);
+			filtersByType.push(this._getFilterByType(field, filterData));
 
 			return filtersByType;
 
-		}, {});
+		}, []);
 	}
 
-	static _getFilterByType(field, filterData) {
+	static _getFilterByType(field, { type, value }) {
 
-		return filterData.reduce((filters, { type, value }) => {
+		const formatter = this.formatters[type];
 
-			const formatter = this.formatters[type];
+		if(!formatter)
+			throw new SolrError(`'${type}' is not a valid or supported filter type.`, SolrError.codes.INVALID_FILTER_TYPE);
 
-			if(!formatter)
-				throw new SolrError(`'${type}' is not a valid or supported filter type.`, SolrError.codes.INVALID_FILTER_TYPE);
+		if(!Array.isArray(value))
+			value = [value];
 
-			const formattedFilter = formatter(field, value);
+		return value.reduce((filters, filter) => {
+
+			if(Array.isArray(filter))
+				throw new SolrError('Invalid filters: Array filtering are not supported by Solr.', SolrError.codes.UNSUPPORTED_FILTER);
+
+			const formattedFilter = isObject(filter) ? this._getFilterByType(field, filter) : formatter(field, filter);
 
 			return filters ? `${filters} OR ${formattedFilter}` : formattedFilter;
 

--- a/tests/helpers/filters.js
+++ b/tests/helpers/filters.js
@@ -42,29 +42,22 @@ describe('Helpers', () => {
 				assert.deepStrictEqual(filters, [
 					'equalDefault:"something"',
 					'customDefault:[32 TO *]',
-					'equal:"something" OR -equal:"foobar"',
+					'equal:"something"',
 					'-notEqual:"something"',
 					'greater:{10 TO *}',
 					'greaterOrEqual:[10 TO *]',
 					'lesser:{* TO 10}',
 					'lesserOrEqual:[* TO 10]',
-					'multiFilters:"some" OR multiFilters:"other" OR multiFilters:{5 TO *}'
+					'multiFilters:"some" OR multiFilters:"other" OR multiFilters:{5 TO *}',
+					'-equal:"foobar"'
 				]);
 			});
 
-			[
+			it('Should throw when the received filters is not supported', () => {
 
-				{ field: { type: 'equal', value: ['array'] } },
-				{ field: { type: 'equal', value: { an: 'object' } } }
-
-			].forEach(filters => {
-
-				it('Should throw when the received filters is not supported', () => {
-
-					assert.throws(() => Filters.build(filters), {
-						name: 'SolrError',
-						code: SolrError.codes.UNSUPPORTED_FILTER
-					});
+				assert.throws(() => Filters.build({ field: { type: 'equal', value: ['somevalue', ['array']] } }), {
+					name: 'SolrError',
+					code: SolrError.codes.UNSUPPORTED_FILTER
 				});
 			});
 


### PR DESCRIPTION
**[QUICK]-FILTER-OPERATOR-FIX**
Solucionar el problema con los filtros multiples, que estaba usando siempre OR en vez de usar tambien AND en los casos correspondientes

**DESCRIPCIÓN DE LA SOLUCIÓN**
Se corrigieron los parseos de los filros para que aplique el operador AND / OR segun corresponda  