### PR TITLE
JCN-276-commit-config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `commitUpdates` (commit) and `commitWithin` settings for update and updateCommands operation support
+- `errorCodes` getter for better error handling
+### Changed
+- `commit` value for update and updatedCommands from `true` to `false` by default
 
 ## [1.2.0] - 2020-04-19
 ### Added

--- a/README.md
+++ b/README.md
@@ -15,6 +15,24 @@ Whenever the `Model` type is mentioned in this document, it refers to an instanc
 
 This is used to configure which collection should be used, which unique indexes it has, among other stuff.
 
+## Getters
+- `errorCodes` *(instance getter)*: Returns an `[Object]` with the Solr [error codes](#Errors) for error handling.
+
+**Example**
+```js
+try {
+
+	await solr.insert(myModel, {my: 'item'});
+
+} catch(err) {
+
+	if(err && err.code === solr.errorCodes.REQUEST_TIMEOUT)
+		return myTimeoutHandler(err);
+
+	throw err;
+}
+```
+
 ## API
 
 ### `new Solr(config)`
@@ -28,6 +46,8 @@ Constructs the Solr driver instance, connected with the `config` object.
 - password `String` (optional but required if an user is specified): Auth password
 - readTimeout `Number` (optional): The read operations timeout in miliseconds. Default: `2000`
 - writeTimeout `Number` (optional): The write operations timeout in miliseconds. Default: `5000`
+- commitUpdates `Boolean` (optional): Set if the write operations should wait until Solr commits all the changes before returning. Default `false`.
+- commitWithin `Number` (optional): Set the time period (in miliseconds) that Solr must take to commit the changes made in write operations. Default: `10`.
 
 **Config usage**
 ```js

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Constructs the Solr driver instance, connected with the `config` object.
 - readTimeout `Number` (optional): The read operations timeout in miliseconds. Default: `2000`
 - writeTimeout `Number` (optional): The write operations timeout in miliseconds. Default: `5000`
 - commitUpdates `Boolean` (optional): Set if the write operations should wait until Solr commits all the changes before returning. Default `false`.
-- commitWithin `Number` (optional): Set the time period (in miliseconds) that Solr must take to commit the changes made in write operations. Default: `10`.
+- commitWithin `Number` (optional): Set the time period (in seconds) that Solr must take to commit the changes made in write operations. Default: `10`.
 
 **Config usage**
 ```js

--- a/lib/config-validator.js
+++ b/lib/config-validator.js
@@ -37,6 +37,8 @@ class ConfigValidator {
 			if(validConfig.user && !validConfig.password)
 				throw new Error(`Password required for user '${validConfig.user}'`);
 
+			validConfig.commitWithin *= 1000;
+
 			return validConfig;
 
 		} catch(err) {

--- a/lib/config-validator.js
+++ b/lib/config-validator.js
@@ -10,10 +10,14 @@ const configStruct = struct.partial({
 	user: 'string?',
 	password: 'string?',
 	readTimeout: 'number?',
-	writeTimeout: 'number?'
+	writeTimeout: 'number?',
+	commitUpdates: 'boolean?',
+	commitWithin: 'number?'
 }, {
 	readTimeout: 2000,
-	writeTimeout: 5000
+	writeTimeout: 5000,
+	commitUpdates: false,
+	commitWithin: 10
 });
 
 class ConfigValidator {

--- a/lib/helpers/endpoint.js
+++ b/lib/helpers/endpoint.js
@@ -10,8 +10,8 @@ class Endpoint {
 
 		return {
 			get: '{{core}}/query',
-			update: '{{core}}/update/json/docs?commit=true',
-			updateCommands: '{{core}}/update?commit=true',
+			update: '{{core}}/update/json/docs?commit={{commitUpdates}}&commitWithin={{commitWithin}}',
+			updateCommands: '{{core}}/update?commit={{commitUpdates}}&commitWithin={{commitWithin}}',
 			schema: '{{core}}/schema',
 			admin: '{{core}}/admin'
 		};

--- a/lib/solr.js
+++ b/lib/solr.js
@@ -45,6 +45,18 @@ class Solr {
 		return this._config.writeTimeout;
 	}
 
+	get commitUpdates() {
+		return this._config.commitUpdates;
+	}
+
+	get commitWithin() {
+		return this._config.commitWithin;
+	}
+
+	get errorCodes() {
+		return SolrError.codes;
+	}
+
 	constructor(config) {
 		this._config = ConfigValidator.validate(config);
 	}
@@ -158,7 +170,10 @@ class Solr {
 
 		item = this._prepareItem(item);
 
-		const endpoint = Endpoint.create(Endpoint.presets.update, this.url, this.core);
+		const endpoint = Endpoint.create(Endpoint.presets.update, this.url, this.core, {
+			commitUpdates: this.commitUpdates,
+			commitWithin: this.commitWithin
+		});
 
 		const res = await Request.post(endpoint, item, this.auth, null, this.writeTimeout);
 
@@ -191,7 +206,10 @@ class Solr {
 
 		items = items.map(this._prepareItem);
 
-		const endpoint = Endpoint.create(Endpoint.presets.update, this.url, this.core);
+		const endpoint = Endpoint.create(Endpoint.presets.update, this.url, this.core, {
+			commitUpdates: this.commitUpdates,
+			commitWithin: this.commitWithin
+		});
 
 		const res = await Request.post(endpoint, items, this.auth, null, this.writeTimeout);
 
@@ -303,7 +321,10 @@ class Solr {
 		if(!item.id)
 			throw new SolrError('Invalid item: Should have an ID.', SolrError.codes.INVALID_PARAMETERS);
 
-		const endpoint = Endpoint.create(Endpoint.presets.updateCommands, this.url, this.core);
+		const endpoint = Endpoint.create(Endpoint.presets.updateCommands, this.url, this.core, {
+			commitUpdates: this.commitUpdates,
+			commitWithin: this.commitWithin
+		});
 
 		const res = await Request.post(endpoint, { delete: { id: item.id } }, this.auth, null, this.writeTimeout);
 
@@ -325,7 +346,10 @@ class Solr {
 
 		const { fields } = model.constructor;
 
-		const endpoint = Endpoint.create(Endpoint.presets.updateCommands, this.url, this.core);
+		const endpoint = Endpoint.create(Endpoint.presets.updateCommands, this.url, this.core, {
+			commitUpdates: this.commitUpdates,
+			commitWithin: this.commitWithin
+		});
 
 		const query = Query.delete({ filters, fields });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@janiscommerce/solr",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/tests/solr-test.js
+++ b/tests/solr-test.js
@@ -103,8 +103,8 @@ describe('Solr', () => {
 	const host = 'http://some-host.com';
 
 	const endpoints = {
-		update: '/solr/some-core/update/json/docs?commit=true',
-		updateCommands: '/solr/some-core/update?commit=true',
+		update: '/solr/some-core/update/json/docs?commit=false&commitWithin=10',
+		updateCommands: '/solr/some-core/update?commit=false&commitWithin=10',
 		get: '/solr/some-core/query',
 		schema: '/solr/some-core/schema',
 		schemaFields: '/solr/some-core/schema/fields',
@@ -135,7 +135,9 @@ describe('Solr', () => {
 			{ url: 'valid', core: 'valid', user: 'valid', password: ['not a string'] },
 			{ url: 'valid', core: 'valid', user: 'valid' },
 			{ url: 'valid', core: 'valid', readTimeout: { not: 'a number' } },
-			{ url: 'valid', core: 'valid', writeTimeout: ['not a number'] }
+			{ url: 'valid', core: 'valid', writeTimeout: ['not a number'] },
+			{ url: 'valid', core: 'valid', commitUpdates: { not: 'a number' } },
+			{ url: 'valid', core: 'valid', commitWithin: ['not a number'] }
 
 		].forEach(config => {
 
@@ -169,6 +171,40 @@ describe('Solr', () => {
 
 			assert.deepEqual(newSolr.readTimeout, 2000);
 			assert.deepEqual(newSolr.writeTimeout, 5000);
+		});
+
+		it('Should not set the commitUpdates and commitWithin defaults when they are already set', () => {
+
+			const newSolr = new Solr({
+				url: host,
+				core: 'some-core',
+				commitUpdates: true,
+				commitWithin: 20
+			});
+
+			assert.deepEqual(newSolr.commitUpdates, true);
+			assert.deepEqual(newSolr.commitWithin, 20);
+		});
+
+		it('Should set the commitUpdates and commitWithin defaults when they are not set', () => {
+
+			const newSolr = new Solr({
+				url: host,
+				core: 'some-core'
+			});
+
+			assert.deepEqual(newSolr.commitUpdates, false);
+			assert.deepEqual(newSolr.commitWithin, 10);
+		});
+	});
+
+	describe('Getters', () => {
+
+		describe('errorCodes', () => {
+
+			it('Should return the Solr error codes object', () => {
+				assert.deepStrictEqual(solr.errorCodes, SolrError.codes);
+			});
 		});
 	});
 

--- a/tests/solr-test.js
+++ b/tests/solr-test.js
@@ -103,8 +103,8 @@ describe('Solr', () => {
 	const host = 'http://some-host.com';
 
 	const endpoints = {
-		update: '/solr/some-core/update/json/docs?commit=false&commitWithin=10',
-		updateCommands: '/solr/some-core/update?commit=false&commitWithin=10',
+		update: '/solr/some-core/update/json/docs?commit=false&commitWithin=10000',
+		updateCommands: '/solr/some-core/update?commit=false&commitWithin=10000',
 		get: '/solr/some-core/query',
 		schema: '/solr/some-core/schema',
 		schemaFields: '/solr/some-core/schema/fields',
@@ -183,7 +183,7 @@ describe('Solr', () => {
 			});
 
 			assert.deepEqual(newSolr.commitUpdates, true);
-			assert.deepEqual(newSolr.commitWithin, 20);
+			assert.deepEqual(newSolr.commitWithin, 20000);
 		});
 
 		it('Should set the commitUpdates and commitWithin defaults when they are not set', () => {
@@ -194,7 +194,7 @@ describe('Solr', () => {
 			});
 
 			assert.deepEqual(newSolr.commitUpdates, false);
-			assert.deepEqual(newSolr.commitWithin, 10);
+			assert.deepEqual(newSolr.commitWithin, 10000);
 		});
 	});
 


### PR DESCRIPTION
**LINK AL TICKET**
https://fizzmod.atlassian.net/browse/JCN-276

**DESCRIPCIÓN DEL REQUERIMIENTO**
- commitUpdates: Boolean, default false. Este dato se debe enviar como commit={commitUpdates} en las requests de Endpoint update y updateCommands. 
- commitWithin: Number, default 10. Este dato se debe enviar como commitWithin={commitWithin} en las requests de Endpoint update y updateCommands.

Estas configuraciones deben estar disponibles para al crear la instancia Solr para ser configurable si así se desea.

**DESCRIPCIÓN DE LA SOLUCIÓN**
Se agregaron las configuraciones solicitadas y se mejoro el acceso a los codigos de error para facilitar el uso del driver