### PR TITLE
QUICK-fix-timeouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `readTimeout` for `ping()` method
 
 ## [1.3.0] - 2020-05-19
 ### Added

--- a/lib/helpers/endpoint.js
+++ b/lib/helpers/endpoint.js
@@ -12,6 +12,9 @@ class Endpoint {
 			get: '{{core}}/query',
 			update: '{{core}}/update/json/docs?commit={{commitUpdates}}&commitWithin={{commitWithin}}',
 			updateCommands: '{{core}}/update?commit={{commitUpdates}}&commitWithin={{commitWithin}}',
+			createCore: 'admin/cores?action=CREATE&name={{name}}&configSet=_default',
+			coreExists: 'admin/cores?action=STATUS&core={{name}}',
+			ping: '{{core}}/admin/ping',
 			schema: '{{core}}/schema',
 			admin: '{{core}}/admin'
 		};

--- a/lib/helpers/endpoint.js
+++ b/lib/helpers/endpoint.js
@@ -12,8 +12,8 @@ class Endpoint {
 			get: '{{core}}/query',
 			update: '{{core}}/update/json/docs?commit={{commitUpdates}}&commitWithin={{commitWithin}}',
 			updateCommands: '{{core}}/update?commit={{commitUpdates}}&commitWithin={{commitWithin}}',
-			createCore: 'admin/cores?action=CREATE&name={{name}}&configSet=_default',
-			coreExists: 'admin/cores?action=STATUS&core={{name}}',
+			createCore: 'admin/cores?action=CREATE&name={{core}}&configSet=_default',
+			coreExists: 'admin/cores?action=STATUS&core={{core}}',
 			ping: '{{core}}/admin/ping',
 			schema: '{{core}}/schema',
 			admin: '{{core}}/admin'

--- a/lib/helpers/request.js
+++ b/lib/helpers/request.js
@@ -10,6 +10,12 @@ const SolrError = require('../solr-error');
 
 class Request {
 
+	constructor(auth, readTimeout, writeTimeout) {
+		this.auth = auth;
+		this.readTimeout = readTimeout;
+		this.writeTimeout = writeTimeout;
+	}
+
 	/**
 	 * Make an http request with method GET to the specified endpoint with the received request body and headers
 	 * @param {String} endpoint the endpoint to make the request
@@ -19,9 +25,9 @@ class Request {
 	 * @returns {Object|Array|null} with the JSON response or null if the request ended with 4XX code
 	 * @throws when the response code is 5XX
 	 */
-	static async get(endpoint, requestBody, auth, headers, timeout) {
-		const httpRequest = this._buildHttpRequest(endpoint, requestBody, auth, headers);
-		return this._makeRequest(httpRequest, 'GET', timeout);
+	async get(endpoint, requestBody, headers) {
+		const httpRequest = this._buildHttpRequest(endpoint, requestBody, headers);
+		return this._makeRequest(httpRequest, 'GET', this.readTimeout);
 	}
 
 	/**
@@ -33,17 +39,17 @@ class Request {
 	 * @returns {Object|Array|null} with the JSON response or null if the request ended with 4XX code
 	 * @throws when the response code is 5XX
 	 */
-	static async post(endpoint, requestBody, auth, headers, timeout) {
-		const httpRequest = this._buildHttpRequest(endpoint, requestBody, auth, headers);
-		return this._makeRequest(httpRequest, 'POST', timeout);
+	async post(endpoint, requestBody, headers) {
+		const httpRequest = this._buildHttpRequest(endpoint, requestBody, headers);
+		return this._makeRequest(httpRequest, 'POST', this.writeTimeout);
 	}
 
-	static _buildHttpRequest(endpoint, body, auth, headers) {
+	_buildHttpRequest(endpoint, body, headers) {
 
 		let credentials;
 
-		if(auth && auth.user && auth.password)
-			credentials = `Basic ${base64(`${auth.user}:${auth.password}`)}`;
+		if(this.auth && this.auth.user && this.auth.password)
+			credentials = `Basic ${base64(`${this.auth.user}:${this.auth.password}`)}`;
 
 		const httpRequest = {
 			url: endpoint,
@@ -60,7 +66,7 @@ class Request {
 		return httpRequest;
 	}
 
-	static async _makeRequest(httpRequest, method, timeout) {
+	async _makeRequest(httpRequest, method, timeout) {
 
 		let response;
 
@@ -80,7 +86,7 @@ class Request {
 		return JSON.parse(body);
 	}
 
-	static _handleError(err) {
+	_handleError(err) {
 
 		if(this._isTimeoutError(err))
 			throw new SolrError(err, SolrError.codes.REQUEST_TIMEOUT);
@@ -88,7 +94,7 @@ class Request {
 		throw new SolrError(err, SolrError.codes.REQUEST_FAILED);
 	}
 
-	static _isTimeoutError(err) {
+	_isTimeoutError(err) {
 		return /TIMEDOUT/g.test(err.code);
 	}
 }

--- a/lib/solr.js
+++ b/lib/solr.js
@@ -57,6 +57,14 @@ class Solr {
 		return SolrError.codes;
 	}
 
+	get request() {
+
+		if(!this._request)
+			this._request = new Request(this.auth, this.readTimeout, this, this.writeTimeout);
+
+		return this._request;
+	}
+
 	constructor(config) {
 		this._config = ConfigValidator.validate(config);
 	}
@@ -67,9 +75,9 @@ class Solr {
 	 */
 	async coreExists() {
 
-		const endpoint = Endpoint.create('admin/cores?action=STATUS&core={{name}}', this.url, null, { name: this.core });
+		const endpoint = Endpoint.create(Endpoint.presets.coreExists, this.url, null, { name: this.core });
 
-		const res = await Request.post(endpoint, null, this.auth, null, this.writeTimeout);
+		const res = await this.request.post(endpoint);
 
 		try {
 
@@ -118,7 +126,7 @@ class Solr {
 
 		const endpoint = Endpoint.create(`${Endpoint.presets.schema}/fields`, this.url, this.core);
 
-		const res = await Request.get(endpoint, null, this.auth, null, this.readTimeout);
+		const res = await this.request.get(endpoint);
 
 		Response.validate(res, {
 			fields: ['object']
@@ -147,7 +155,7 @@ class Solr {
 
 		const endpoint = Endpoint.create(Endpoint.presets.schema, this.url, this.core);
 
-		const res = await Request.post(endpoint, query, this.auth, null, this.writeTimeout);
+		const res = await this.request.post(endpoint, query);
 
 		return Response.validate(res);
 	}
@@ -175,7 +183,7 @@ class Solr {
 			commitWithin: this.commitWithin
 		});
 
-		const res = await Request.post(endpoint, item, this.auth, null, this.writeTimeout);
+		const res = await this.request.post(endpoint, item);
 
 		Response.validate(res);
 
@@ -211,7 +219,7 @@ class Solr {
 			commitWithin: this.commitWithin
 		});
 
-		const res = await Request.post(endpoint, items, this.auth, null, this.writeTimeout);
+		const res = await this.request.post(endpoint, items);
 
 		Response.validate(res);
 
@@ -258,7 +266,7 @@ class Solr {
 
 		const query = Query.get({ ...params, page, limit, fields });
 
-		const res = await Request.get(endpoint, query, this.auth, null, this.readTimeout);
+		const res = await this.request.get(endpoint, query);
 
 		Response.validate(res, {
 			response: { docs: ['object'] }
@@ -288,7 +296,7 @@ class Solr {
 
 		const endpoint = Endpoint.create(Endpoint.presets.get, this.url, this.core);
 
-		const res = await Request.get(endpoint, query, this.auth, null, this.readTimeout);
+		const res = await this.request.get(endpoint, query);
 
 		Response.validate(res, {
 			response: { numFound: 'number' }
@@ -326,7 +334,7 @@ class Solr {
 			commitWithin: this.commitWithin
 		});
 
-		const res = await Request.post(endpoint, { delete: { id: item.id } }, this.auth, null, this.writeTimeout);
+		const res = await this.request.post(endpoint, { delete: { id: item.id } });
 
 		return Response.validate(res);
 	}
@@ -353,7 +361,7 @@ class Solr {
 
 		const query = Query.delete({ filters, fields });
 
-		const res = await Request.post(endpoint, query, this.auth, null, this.writeTimeout);
+		const res = await this.request.post(endpoint, query);
 
 		return Response.validate(res);
 	}
@@ -381,7 +389,7 @@ class Solr {
 
 		const query = Query.distinct({ ...params, limit, page, fields });
 
-		const res = await Request.get(endpoint, query, this.auth, null, this.readTimeout);
+		const res = await this.request.get(endpoint, query);
 
 		Response.validate(res, {
 			response: { docs: ['object'] }
@@ -398,11 +406,11 @@ class Solr {
 	 */
 	async ping() {
 
-		const endpoint = Endpoint.create(`${Endpoint.presets.admin}/ping`, this.url, this.core);
+		const endpoint = Endpoint.create(Endpoint.presets.ping, this.url, this.core);
 
 		try {
 
-			const res = await Request.get(endpoint, null, this.auth, null, this.readTimeout);
+			const res = await this.request.get(endpoint);
 
 			Response.validate(res, {
 				status: 'string'
@@ -422,8 +430,8 @@ class Solr {
 		if(coreExists)
 			return;
 
-		const endpoint = Endpoint.create('admin/cores?action=CREATE&name={{name}}&configSet=_default', this.url, null, { name: this.core });
-		const res = await Request.post(endpoint, null, this.auth, null, this.writeTimeout);
+		const endpoint = Endpoint.create(Endpoint.presets.createCore, this.url, null, { name: this.core });
+		const res = await this.request.post(endpoint);
 
 		Response.validate(res);
 	}

--- a/lib/solr.js
+++ b/lib/solr.js
@@ -75,7 +75,7 @@ class Solr {
 	 */
 	async coreExists() {
 
-		const endpoint = Endpoint.create(Endpoint.presets.coreExists, this.url, null, { name: this.core });
+		const endpoint = Endpoint.create(Endpoint.presets.coreExists, this.url, this.core);
 
 		const res = await this.request.post(endpoint);
 
@@ -430,7 +430,7 @@ class Solr {
 		if(coreExists)
 			return;
 
-		const endpoint = Endpoint.create(Endpoint.presets.createCore, this.url, null, { name: this.core });
+		const endpoint = Endpoint.create(Endpoint.presets.createCore, this.url, this.core);
 		const res = await this.request.post(endpoint);
 
 		Response.validate(res);

--- a/lib/solr.js
+++ b/lib/solr.js
@@ -402,7 +402,7 @@ class Solr {
 
 		try {
 
-			const res = await Request.get(endpoint, null, this.auth);
+			const res = await Request.get(endpoint, null, this.auth, null, this.readTimeout);
 
 			Response.validate(res, {
 				status: 'string'

--- a/tests/helpers/request.js
+++ b/tests/helpers/request.js
@@ -11,6 +11,12 @@ describe('Helpers', () => {
 
 	describe('Request', () => {
 
+		let requestInstance;
+
+		beforeEach(() => {
+			requestInstance = new Request(null, 2000, 2000);
+		});
+
 		afterEach(() => {
 			nock.cleanAll();
 		});
@@ -30,7 +36,7 @@ describe('Helpers', () => {
 					.delay(5000)
 					.reply(200);
 
-				await assert.rejects(Request.get(url, null, null, null, 2000), {
+				await assert.rejects(requestInstance.get(url), {
 					name: 'SolrError',
 					code: SolrError.codes.REQUEST_TIMEOUT
 				});
@@ -42,7 +48,7 @@ describe('Helpers', () => {
 
 				nock.disableNetConnect();
 
-				await assert.rejects(Request.get(url), {
+				await assert.rejects(requestInstance.get(url), {
 					name: 'SolrError',
 					code: SolrError.codes.REQUEST_FAILED
 				});
@@ -58,7 +64,7 @@ describe('Helpers', () => {
 					.delay(5000)
 					.reply(200);
 
-				await assert.rejects(Request.post(url, null, null, null, 2000), {
+				await assert.rejects(requestInstance.post(url), {
 					name: 'SolrError',
 					code: SolrError.codes.REQUEST_TIMEOUT
 				});
@@ -70,7 +76,7 @@ describe('Helpers', () => {
 
 				nock.disableNetConnect();
 
-				await assert.rejects(Request.post(url), {
+				await assert.rejects(requestInstance.post(url), {
 					name: 'SolrError',
 					code: SolrError.codes.REQUEST_FAILED
 				});


### PR DESCRIPTION
**DESCRIPCIÓN DEL REQUERIMIENTO**
-Agregar el `readTimeout` a todos los metodos que usen `get` y `writeTimeout` a todos los metodos que usen `post`.

**DESCRIPCIÓN DE LA SOLUCIÓN**
Se agrego el `readTimeout` al metodo `ping`, que era el unico que no usaba timeouts.